### PR TITLE
Replace the service name in docker compose file.

### DIFF
--- a/scripts/create_workspace.sh
+++ b/scripts/create_workspace.sh
@@ -41,5 +41,8 @@ echo "# ${NEW_WS_NAME_UNDERSCORE}" > "${NEW_WS_DIR}/README.md"
 
 # Replace the "template_ws" with new workspace name in each file.
 sed -i "s/template_ws/${NEW_WS_NAME_UNDERSCORE}/g" "${NEW_WS_DIR}/.devcontainer/devcontainer.json"
+sed -i "s/template-ws/${NEW_WS_NAME_HYPHEN}/g"     "${NEW_WS_DIR}/.devcontainer/devcontainer.json"
 sed -i "s/template_ws/${NEW_WS_NAME_UNDERSCORE}/g" "${NEW_WS_DIR}/docker/compose.yaml"
 sed -i "s/template-ws/${NEW_WS_NAME_HYPHEN}/g"     "${NEW_WS_DIR}/docker/compose.yaml"
+
+echo "Done."

--- a/template_ws/.devcontainer/devcontainer.json
+++ b/template_ws/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 /* Reference: https://aka.ms/devcontainer.json */
 {
-    "name": "ROS 2 Development Container",
+    "name": "template-ws",
     "dockerComposeFile": "../docker/compose.yaml",
-    "service": "ros2",
+    "service": "template-ws",
     // workspace settings
     "workspaceFolder": "/home/ros2-agv-essentials/template_ws",
     // Vscode extensions

--- a/template_ws/docker/compose.yaml
+++ b/template_ws/docker/compose.yaml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  ros2:
+  template-ws:
     build: .
     image: j3soon/ros2-template-ws
     container_name: ros2-template-ws


### PR DESCRIPTION
If the docker service name is the same, the compose file that runs second will recreate the first file's container. 
This may lead to issues such as data loss when opening the second container simultaneously. 

There are two possible solutions: one is to replace the service name in the compose file, and the other is to add the parameter `--project-name` to specify an alternate project name for docker compose. I chose the first solution in this pull request because it is easier to understand.

Reference: https://github.com/docker/compose/issues/7403